### PR TITLE
Fix Preprocess images button in Gradio demo

### DIFF
--- a/demo_gr.py
+++ b/demo_gr.py
@@ -1147,6 +1147,12 @@ def main(server_port: int | None = None, share: bool = True):
                                 ],
                             )
                             preprocessed = gr.State()
+                            # Enable the Preprocess Images button when images are uploaded
+                            input_imgs.change(
+                                lambda imgs: gr.update(interactive=bool(imgs)),
+                                inputs=[input_imgs],
+                                outputs=[preprocess_btn],
+                            )
                             preprocess_btn.click(
                                 lambda r, *args: r.preprocess(*args),
                                 inputs=[renderer, input_imgs],


### PR DESCRIPTION
There is currently a bug in the Gradio demo. In advanced tab, when you upload your own images, the `Preprocess Images` but remains disabled. See screenshot below -

![Screenshot 2025-03-24 at 4 08 35 PM](https://github.com/user-attachments/assets/64b88517-de98-495e-b476-a424cc46a725)
